### PR TITLE
fixed autocomplete regex error

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -248,7 +248,6 @@ def find_meeting_place(start_1, start_2, count):
     results = sorted(potential, key=lambda x: x['time'])[:count]
 
     limit = costs_1[get_full_name(start_2)]
-    print(limit)
     while results[0]['time'] > limit:
         blur_factor += 1
         potential = recur_try(blur_factor, costs_1, costs_2)

--- a/server/react/src/AutocompleteBox.jsx
+++ b/server/react/src/AutocompleteBox.jsx
@@ -11,7 +11,8 @@ class AutocompleteBox extends React.Component {
 
   render() {
     // escape regex characters
-    const re = new RegExp(this.props.inputValue.replace(/[#-}]/g, '\\$&'));
+    const re = new RegExp(this.props.inputValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    console.log(re)
     return (
       <div className="AutocompleteBox">
         {this.props.optionList


### PR DESCRIPTION
Successfully debugged autocomplete. The regex was replacing too many characters, including single letters, resulting in search strings like \\t\h\i\s\&\t\h\a\t\ rather than \this\&that\.